### PR TITLE
dynamic coupons

### DIFF
--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -9,11 +9,10 @@ class HX_Dynamic_Coupon {
   }
 
   function filter_woocommerce_get_shop_coupon_data($false, $data){
-    Hexly::info('$data', $data);
     global $hexly_fed_graphql;
 
     try {
-      $res = $hexly_fed_graphql->execute(<<<QUERY
+      $res = $hexly_fed_graphql->exec(<<<QUERY
         query couponSearch(\$input: CouponSearchInput!) {
           comp {
             couponSearch(input: \$input) {
@@ -25,20 +24,20 @@ class HX_Dynamic_Coupon {
           }
         }
       QUERY, [ 'input' => [ 'code' => $data ] ]);
-      Hexly::info('$res', $res);
+      $res_data = $res->comp->couponSearch;
+      $res_is_empty = empty($res_data);
+
+      if ($res_is_null) {
+        return false;
+      }
     } catch (\Throwable $th) {
       echo $th->xdebug_message;
-      // Hexly::panic('Graphql Error!', $th->xdebug_message);
+      Hexly::panic('Graphql Error!');
     }
 
-    $mock_res = (object)[
-      'code' => $data,
-      'amount' => 100
-    ];
-
     $new_coupon = [
-      'code' => $mock_res->code,
-      'amount' => $mock_res->amount,
+      'code' => $res_data->code,
+      'amount' => $res_data->amount,
       'date_created' => null,
       'date_modified' => null,
       'date_expires' => null,

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -70,10 +70,12 @@ class HX_Dynamic_Coupon {
 
   function action_woocommerce_checkout_order_processed() {
     Hexly::info('action_woocommerce_checkout_order_processed()');
+    // TODO: Send message to hexly that the coupon code was used
   }
 
   function action_woocommerce_removed_coupon($coupon_code) {
     Hexly::info('action_woocommerce_removed_coupon() $coupon_code', $coupon_code);
+    // TODO: Send message to hexly that the coupon code was not used? (May not be necessary)
   }
 
 }

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -9,6 +9,28 @@ class HX_Dynamic_Coupon {
   }
 
   function filter_woocommerce_get_shop_coupon_data($false, $data){
+    Hexly::info('$data', $data);
+    global $hexly_fed_graphql;
+
+    try {
+      $res = $hexly_fed_graphql->execute(<<<QUERY
+        query couponSearch(\$input: CouponSearchInput!) {
+          comp {
+            couponSearch(input: \$input) {
+              id
+              amount
+              name
+              expiration
+            }
+          }
+        }
+      QUERY, [ 'input' => [ 'code' => $data ] ]);
+      Hexly::info('$res', $res);
+    } catch (\Throwable $th) {
+      echo $th->xdebug_message;
+      // Hexly::panic('Graphql Error!', $th->xdebug_message);
+    }
+
     $mock_res = (object)[
       'code' => $data,
       'amount' => 100

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -8,40 +8,54 @@ class HX_Dynamic_Coupon {
     add_action('woocommerce_removed_coupon', [$this, 'action_woocommerce_removed_coupon']);
   }
 
-  function filter_woocommerce_get_shop_coupon_data($false, $data){
-    if ($false || !$data) {
-      return false;
+  function filter_woocommerce_get_shop_coupon_data($filtered, $data){
+    // we only run this logic if there's nothing found yet
+    if ( $filtered !== false ) {
+      return $filtered;
     }
-    global $hexly_fed_graphql;
+
+    // if the passed info isn't just a string, we're out
+    if( !is_string($data) ){
+      return $filtered;
+    }
+
+    $code = $data;
+
+    $details = $this->search_hexly_for_coupon($data);
+    if( empty($details) ){
+      return $filtered;
+    }
+
+    if( $details->status !== 'ISSUED' ){
+      Hexly::info("Unexpected status; not applying $code", $details);
+      return $filtered;
+    }
+
 
     try {
-      $res = $hexly_fed_graphql->exec(<<<QUERY
-        query couponSearch(\$input: CouponSearchInput!) {
-          comp {
-            couponSearch(input: \$input) {
-              id
-              amount
-              code
-              expiration
-            }
-          }
-        }
-      QUERY, [ 'input' => [ 'code' => $data ] ]);
-      $res_data = $res->comp->couponSearch;
-      $res_is_empty = empty($res_data);
-
-      if ($res_is_empty) {
-        Hexly::warn('No coupon data found!', $res);
-        return false;
-      }
-    } catch (\Throwable $th) {
-      echo $th->xdebug_message;
-      Hexly::panic('Graphql Error!');
+      $result = $this->parse_details($code, $details);
+      return $result;
+    }catch(Throwable $err){
+      Hexly::warn("Failed parsing coupon $code: " . $err->getMessage(), $details, $err);
+      return $filtered;
     }
+  }
 
-    $new_coupon = [
-      'code' => $res_data->code,
-      'amount' => $res_data->amount,
+  private function search_hexly_for_coupon($code){
+    global $hexly_fed_graphql;
+    try {
+      $res = $hexly_fed_graphql->exec(self::QUERY, [ 'input' => [ 'code' => $code ] ]);
+      // handle error?
+      $res = $res->marketing->couponByCode ?? null;
+      return empty($res) ? null : $res;
+    } catch (\Throwable $th) {
+      Hexly::panic('Graphql Error!', $th);
+    }
+  }
+
+  private function parse_details($code, $details) {
+    $result = [
+      'code' => $details->code,
       'date_created' => null,
       'date_modified' => null,
       'date_expires' => null,
@@ -65,47 +79,57 @@ class HX_Dynamic_Coupon {
       'virtual' => false
     ];
 
-    return $new_coupon;
-  }
+    switch($details->type){
+      case 'FIXED_CART_AMOUNT':
+        $currency = 'USD'; // TODO @narfdre
+        $currency_mod = .01; // normalize from pennies
+        $currency_dec = 2; // round to the nearest 2 dec
+        $amount = $details->config->amounts->$currency ?? null;
 
-  function action_woocommerce_thankyou($order_id) {
-    global $hexly_fed_graphql;
-
-    $order_just_processed = new WC_Order($order_id);
-    $order_coupons = $order_just_processed->get_coupons();
-    $order_coupon_codes = [];
-    foreach ($order_coupons as $coupon) {
-      array_push($order_coupon_codes, $coupon->get_code());
-    }
-
-    $no_codes_used = empty($order_coupon_codes);
-    if ($no_codes_used) {
-      return;
-    }
-
-    try {
-      $res = $hexly_fed_graphql->exec(<<<QUERY
-        mutation couponUsed(\$input: CouponUsedInput!) {
-          comp {
-            couponUsed(input: \$input) {
-              id
-              amount
-              code
-              expiration
-            }
-          }
+        if( !is_numeric($amount) ){
+          throw new Error("Invalid amount for coupon code $code in currency $currency", $details);
         }
-      QUERY, [ 'input' => [ 'codes' => $order_coupon_codes ] ]);
-    } catch (\Throwable $th) {
-      echo $th->xdebug_message;
-      Hexly::panic('Graphql mutation Error!');
+
+        $result['discount_type'] = 'fixed_cart';
+        $result['amount'] = round($amount * $currency_mod, $currency_dec);
+        break;
+
+      case 'FREE_PRODUCT':
+        $options = $details->config->options ?? [];
+        $tid = get_option('hexly_wp_auth_integration_id') ?? 'not-found';
+        $def = array_filter($options, function($o) use ($tid) {
+          return $o->tenantIntegrationId == $tid;
+        });
+        Hexly::info('need to handle', $def, $tid); // tODO start here
+        break;
+
+      default:
+        throw new Error('Could not handle coupon type for ' . $code);
     }
+
+    return $result;
   }
 
   function action_woocommerce_removed_coupon($coupon_code) {
     Hexly::info('action_woocommerce_removed_coupon() $coupon_code', $coupon_code);
     // TODO: Send message to hexly that the coupon code was not used? (May not be necessary)
   }
+
+  const QUERY = <<<QUERY
+      query couponByCode(\$input: CouponSearchInput!) {
+        marketing {
+          couponByCode(input: \$input) {
+            id
+            type
+            status
+            config
+            metadata
+            code
+            expiresOn
+          }
+        }
+      }
+  QUERY;
 
 }
 

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -168,7 +168,13 @@ class HX_Dynamic_Coupon {
 
     switch($details->type){
       case 'FIXED_CART_AMOUNT':
-        $currency = 'USD'; // TODO @narfdre
+        $currency = 'USD'; // default
+        if( class_exists('WCPBC_Pricing_Zones') ){
+          $current_zone = wcpbc()->current_zone;
+          if(!empty($current_zone)){
+            $currency = strtoupper($zone->get_currency()); // Normalizing just in case
+          }
+        }
         $currency_mod = .01; // normalize from pennies
         $currency_dec = 2; // round to the nearest 2 dec
         $amount = $details->config->amounts->$currency ?? null;
@@ -196,6 +202,7 @@ class HX_Dynamic_Coupon {
 
     $coupon->read_manual_coupon($code, $result);
     $coupon->update_meta_data(self::META_DETAILS_KEY, $details);
+    apply_filters('_hx_dynamic_coupon_processed', $coupon, $details);
     return $coupon;
   }
 

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -18,7 +18,7 @@ class HX_Dynamic_Coupon {
             couponSearch(input: \$input) {
               id
               amount
-              name
+              code
               expiration
             }
           }
@@ -42,7 +42,7 @@ class HX_Dynamic_Coupon {
       'date_modified' => null,
       'date_expires' => null,
       'discount_type' => 'fixed_cart',
-      'description' => '',
+      'description' => 'description',
       'usage_count' => 0,
       'individual_use' => false,
       'product_ids' => array(),

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -202,7 +202,7 @@ class HX_Dynamic_Coupon {
 
     $coupon->read_manual_coupon($code, $result);
     $coupon->update_meta_data(self::META_DETAILS_KEY, $details);
-    apply_filters('_hx_dynamic_coupon_processed', $coupon, $details);
+    $coupon = apply_filters('_hx_dynamic_coupon_processed', $coupon, $details);
     return $coupon;
   }
 

--- a/inc/coupons/class-hx-dynamic-coupon.php
+++ b/inc/coupons/class-hx-dynamic-coupon.php
@@ -4,11 +4,14 @@
 class HX_Dynamic_Coupon {
   public function __construct() {
     add_filter('woocommerce_get_shop_coupon_data', [$this, 'filter_woocommerce_get_shop_coupon_data'], 10, 2);
-    add_action('woocommerce_applied_coupon', [$this, 'action_woocommerce_applied_coupon']);
+    add_action('woocommerce_checkout_order_processed', [$this, 'action_woocommerce_checkout_order_processed']);
     add_action('woocommerce_removed_coupon', [$this, 'action_woocommerce_removed_coupon']);
   }
 
   function filter_woocommerce_get_shop_coupon_data($false, $data){
+    if ($false || !$data) {
+      return false;
+    }
     global $hexly_fed_graphql;
 
     try {
@@ -27,7 +30,8 @@ class HX_Dynamic_Coupon {
       $res_data = $res->comp->couponSearch;
       $res_is_empty = empty($res_data);
 
-      if ($res_is_null) {
+      if ($res_is_empty) {
+        Hexly::warn('No coupon data found!', $res);
         return false;
       }
     } catch (\Throwable $th) {
@@ -64,8 +68,8 @@ class HX_Dynamic_Coupon {
     return $new_coupon;
   }
 
-  function action_woocommerce_applied_coupon($coupon_code) {
-    Hexly::info('action_woocommerce_applied_coupon() $coupon_code', $coupon_code);
+  function action_woocommerce_checkout_order_processed() {
+    Hexly::info('action_woocommerce_checkout_order_processed()');
   }
 
   function action_woocommerce_removed_coupon($coupon_code) {


### PR DESCRIPTION
- adds graphql query. Having trouble getting it to run on my local box, but it may be unrelated to this code
- stubs out graphql coupon functionality
- changes 'name' to 'code' in query
- stubbed out dynamic coupons working
- adds a few 'TODO' comments
- logic for notifying hexly on coupon use
- snapshot
- cache via session + transient
- dynamic coupns
- adding currency and filters
- oop
- ready to go live
